### PR TITLE
oci: layer: add xattrs to new layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,18 +21,21 @@ MAINTAINER "Aleksa Sarai <asarai@suse.com>"
 RUN zypper ar -f -p 10 -g obs://Virtualization:containers obs-vc && \
     zypper ar -f -p 10 -g obs://devel:languages:go obs-dlg && \
     zypper ar -f -p 15 -g obs://home:cyphar obs-home-cyphar && \
+    zypper ar -f -p 15 -g obs://devel:languages:python3 obs-py3k && \
 	zypper --gpg-auto-import-keys -n ref && \
 	zypper -n up
 RUN zypper -n in \
 		bats \
 		git \
 		'go>=1.6' \
-		go-mtree \
 		golang-github-cpuguy83-go-md2man \
+		go-mtree \
 		jq \
 		make \
 		oci-image-tools \
 		oci-runtime-tools \
+		python3-setuptools \
+		python3-xattr \
 		skopeo
 
 ENV GOPATH /go

--- a/cmd/umoci/repack.go
+++ b/cmd/umoci/repack.go
@@ -135,10 +135,8 @@ func repack(ctx *cli.Context) error {
 		return errors.Wrap(err, "parse mtree")
 	}
 
-	keywords := spec.UsedKeywords()
-
 	logrus.WithFields(logrus.Fields{
-		"keywords": keywords,
+		"keywords": MtreeKeywords,
 	}).Debugf("umoci: parsed mtree spec")
 
 	fsEval := umoci.DefaultFsEval
@@ -146,7 +144,7 @@ func repack(ctx *cli.Context) error {
 		fsEval = umoci.RootlessFsEval
 	}
 
-	diffs, err := mtree.Check(fullRootfsPath, spec, keywords, fsEval)
+	diffs, err := mtree.Check(fullRootfsPath, spec, MtreeKeywords, fsEval)
 	if err != nil {
 		return errors.Wrap(err, "check mtree")
 	}

--- a/cmd/umoci/unpack.go
+++ b/cmd/umoci/unpack.go
@@ -196,7 +196,7 @@ func unpack(ctx *cli.Context) error {
 	}
 
 	// Create the mtree manifest.
-	keywords := append(mtree.DefaultKeywords[:], "sha256digest")
+	keywords := append(mtree.DefaultKeywords[:], "sha256digest", "xattrs")
 	for idx, kw := range keywords {
 		// We have to use tar_time because we're extracting from a tar archive.
 		if kw == "time" {

--- a/cmd/umoci/unpack.go
+++ b/cmd/umoci/unpack.go
@@ -195,17 +195,8 @@ func unpack(ctx *cli.Context) error {
 		return errors.Wrap(err, "create runtime bundle")
 	}
 
-	// Create the mtree manifest.
-	keywords := append(mtree.DefaultKeywords[:], "sha256digest", "xattrs")
-	for idx, kw := range keywords {
-		// We have to use tar_time because we're extracting from a tar archive.
-		if kw == "time" {
-			keywords[idx] = "tar_time"
-		}
-	}
-
 	logrus.WithFields(logrus.Fields{
-		"keywords": keywords,
+		"keywords": MtreeKeywords,
 		"mtree":    mtreePath,
 	}).Debugf("umoci: generating mtree manifest")
 
@@ -214,7 +205,7 @@ func unpack(ctx *cli.Context) error {
 		fsEval = umoci.RootlessFsEval
 	}
 
-	dh, err := mtree.Walk(fullRootfsPath, nil, keywords, fsEval)
+	dh, err := mtree.Walk(fullRootfsPath, nil, MtreeKeywords, fsEval)
 	if err != nil {
 		return errors.Wrap(err, "generate mtree spec")
 	}

--- a/cmd/umoci/utils.go
+++ b/cmd/umoci/utils.go
@@ -32,6 +32,7 @@ import (
 	"github.com/docker/go-units"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"github.com/vbatts/go-mtree"
 	"golang.org/x/net/context"
 )
 
@@ -40,6 +41,22 @@ import (
 //        can be useful to other people. This is _particularly_ true for the
 //        code which repacks images (the changes to the config, manifest and
 //        CAS should be made into a library).
+
+// MtreeKeywords is the set of keywords used by umoci for verification and diff
+// generation of a bundle. This is based on mtree.DefaultKeywords, but is
+// hardcoded here to ensure that vendor changes don't mess things up.
+var MtreeKeywords = []mtree.Keyword{
+	"size",
+	"type",
+	"uid",
+	"gid",
+	"mode",
+	"link",
+	"nlink",
+	"tar_time",
+	"sha256digest",
+	"xattr",
+}
 
 // UmociMetaName is the name of umoci's metadata file that is stored in all
 // bundles extracted by umoci.

--- a/fseval.go
+++ b/fseval.go
@@ -33,47 +33,62 @@ var _ mtree.FsEval = RootlessFsEval
 // mtree.FsEval as well as including all of the imporant os.* wrapper functions
 // needed for "oci/layers".tarExtractor.
 type FsEval interface {
-	// Open is a wrapper around unpriv.Open.
+	// Open is equivalent to os.Open.
 	Open(path string) (*os.File, error)
 
-	// Create is a wrapper around unpriv.Create.
+	// Create is equivalent to os.Create.
 	Create(path string) (*os.File, error)
 
-	// Readdir is a wrapper around unpriv.Readdir.
+	// Readdir is equivalent to os.Readdir.
 	Readdir(path string) ([]os.FileInfo, error)
 
-	// Lstat is a wrapper around unpriv.Lstat.
+	// Lstat is equivalent to os.Lstat.
 	Lstat(path string) (os.FileInfo, error)
 
-	// Readlink is a wrapper around unpriv.Readlink.
+	// Readlink is equivalent to os.Readlink.
 	Readlink(path string) (string, error)
 
-	// Symlink is a wrapper around unpriv.Symlink.
+	// Symlink is equivalent to os.Symlink.
 	Symlink(linkname, path string) error
 
-	// Link is a wrapper around unpriv.Link.
+	// Link is equivalent to os.Link.
 	Link(linkname, path string) error
 
-	// Chmod is a wrapper around unpriv.Chmod.
+	// Chmod is equivalent to os.Chmod.
 	Chmod(path string, mode os.FileMode) error
 
-	// Lutimes is a wrapper around unpriv.Lutimes.
+	// Lutimes is equivalent to os.Lutimes.
 	Lutimes(path string, atime, mtime time.Time) error
 
-	// Remove is a wrapper around unpriv.Remove.
+	// Remove is equivalent to os.Remove.
 	Remove(path string) error
 
-	// RemoveAll is a wrapper around unpriv.RemoveAll.
+	// RemoveAll is equivalent to os.RemoveAll.
 	RemoveAll(path string) error
 
-	// Mkdir is a wrapper around unpriv.Mkdir.
+	// Mkdir is equivalent to os.Mkdir.
 	Mkdir(path string, perm os.FileMode) error
 
-	// MkdirAll is a wrapper around unpriv.MkdirAll.
+	// MkdirAll is equivalent to os.MkdirAll.
 	MkdirAll(path string, perm os.FileMode) error
 
 	// Mknod is equivalent to system.Mknod.
 	Mknod(path string, mode os.FileMode, dev system.Dev_t) error
+
+	// Llistxattr is equivalent to system.Llistxattr
+	Llistxattr(path string) ([]string, error)
+
+	// Lremovexattr is equivalent to system.Lremovexattr
+	Lremovexattr(path, name string) error
+
+	// Lsetxattr is equivalent to system.Lsetxattr
+	Lsetxattr(path, name string, value []byte, flags int) error
+
+	// Lgetxattr is equivalent to system.Lgetxattr
+	Lgetxattr(path string, name string) ([]byte, error)
+
+	// Lclearxattrs is equivalent to system.Lclearxattrs
+	Lclearxattrs(path string) error
 
 	// KeywordFunc returns a wrapper around the given mtree.KeywordFunc.
 	KeywordFunc(fn mtree.KeywordFunc) mtree.KeywordFunc

--- a/fseval_default.go
+++ b/fseval_default.go
@@ -31,20 +31,20 @@ import (
 // weird side-effects.
 var DefaultFsEval FsEval = osFsEval(0)
 
-// unprivFsEval is a hack to be able to make DefaultFsEval a const.
+// osFsEval is a hack to be able to make DefaultFsEval a const.
 type osFsEval int
 
-// Open is a wrapper around unpriv.Open.
+// Open is equivalent to os.Open.
 func (fs osFsEval) Open(path string) (*os.File, error) {
 	return os.Open(path)
 }
 
-// Create is a wrapper around unpriv.Create.
+// Create is equivalent to os.Create.
 func (fs osFsEval) Create(path string) (*os.File, error) {
 	return os.Create(path)
 }
 
-// Readdir is a wrapper around unpriv.Readdir.
+// Readdir is equivalent to os.Readdir.
 func (fs osFsEval) Readdir(path string) ([]os.FileInfo, error) {
 	fh, err := os.Open(path)
 	if err != nil {
@@ -54,47 +54,47 @@ func (fs osFsEval) Readdir(path string) ([]os.FileInfo, error) {
 	return fh.Readdir(-1)
 }
 
-// Lstat is a wrapper around unpriv.Lstat.
+// Lstat is equivalent to os.Lstat.
 func (fs osFsEval) Lstat(path string) (os.FileInfo, error) {
 	return os.Lstat(path)
 }
 
-// Readlink is a wrapper around unpriv.Readlink.
+// Readlink is equivalent to os.Readlink.
 func (fs osFsEval) Readlink(path string) (string, error) {
 	return os.Readlink(path)
 }
 
-// Symlink is a wrapper around unpriv.Symlink.
+// Symlink is equivalent to os.Symlink.
 func (fs osFsEval) Symlink(linkname, path string) error {
 	return os.Symlink(linkname, path)
 }
 
-// Link is a wrapper around unpriv.Link.
+// Link is equivalent to os.Link.
 func (fs osFsEval) Link(linkname, path string) error {
 	return os.Link(linkname, path)
 }
 
-// Chmod is a wrapper around unpriv.Chmod.
+// Chmod is equivalent to os.Chmod.
 func (fs osFsEval) Chmod(path string, mode os.FileMode) error {
 	return os.Chmod(path, mode)
 }
 
-// Lutimes is a wrapper around unpriv.Lutimes.
+// Lutimes is equivalent to os.Lutimes.
 func (fs osFsEval) Lutimes(path string, atime, mtime time.Time) error {
 	return system.Lutimes(path, atime, mtime)
 }
 
-// Remove is a wrapper around unpriv.Remove.
+// Remove is equivalent to os.Remove.
 func (fs osFsEval) Remove(path string) error {
 	return os.Remove(path)
 }
 
-// RemoveAll is a wrapper around unpriv.RemoveAll.
+// RemoveAll is equivalent to os.RemoveAll.
 func (fs osFsEval) RemoveAll(path string) error {
 	return os.RemoveAll(path)
 }
 
-// Mkdir is a wrapper around unpriv.Mkdir.
+// Mkdir is equivalent to os.Mkdir.
 func (fs osFsEval) Mkdir(path string, perm os.FileMode) error {
 	return os.Mkdir(path, perm)
 }
@@ -104,9 +104,34 @@ func (fs osFsEval) Mknod(path string, mode os.FileMode, dev system.Dev_t) error 
 	return system.Mknod(path, mode, dev)
 }
 
-// MkdirAll is a wrapper around unpriv.MkdirAll.
+// MkdirAll is equivalent to os.MkdirAll.
 func (fs osFsEval) MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
+}
+
+// Llistxattr is equivalent to system.Llistxattr
+func (fs osFsEval) Llistxattr(path string) ([]string, error) {
+	return system.Llistxattr(path)
+}
+
+// Lremovexattr is equivalent to system.Lremovexattr
+func (fs osFsEval) Lremovexattr(path, name string) error {
+	return system.Lremovexattr(path, name)
+}
+
+// Lsetxattr is equivalent to system.Lsetxattr
+func (fs osFsEval) Lsetxattr(path, name string, value []byte, flags int) error {
+	return system.Lsetxattr(path, name, value, flags)
+}
+
+// Lgetxattr is equivalent to system.Lgetxattr
+func (fs osFsEval) Lgetxattr(path string, name string) ([]byte, error) {
+	return system.Lgetxattr(path, name)
+}
+
+// Lclearxattrs is equivalent to system.Lclearxattrs
+func (fs osFsEval) Lclearxattrs(path string) error {
+	return system.Lclearxattrs(path)
 }
 
 // KeywordFunc returns a wrapper around the given mtree.KeywordFunc.

--- a/fseval_rootless.go
+++ b/fseval_rootless.go
@@ -37,62 +37,62 @@ var RootlessFsEval FsEval = unprivFsEval(0)
 // unprivFsEval is a hack to be able to make RootlessFsEval a const.
 type unprivFsEval int
 
-// Open is a wrapper around unpriv.Open.
+// Open is equivalent to unpriv.Open.
 func (fs unprivFsEval) Open(path string) (*os.File, error) {
 	return unpriv.Open(path)
 }
 
-// Create is a wrapper around unpriv.Create.
+// Create is equivalent to unpriv.Create.
 func (fs unprivFsEval) Create(path string) (*os.File, error) {
 	return unpriv.Create(path)
 }
 
-// Readdir is a wrapper around unpriv.Readdir.
+// Readdir is equivalent to unpriv.Readdir.
 func (fs unprivFsEval) Readdir(path string) ([]os.FileInfo, error) {
 	return unpriv.Readdir(path)
 }
 
-// Lstat is a wrapper around unpriv.Lstat.
+// Lstat is equivalent to unpriv.Lstat.
 func (fs unprivFsEval) Lstat(path string) (os.FileInfo, error) {
 	return unpriv.Lstat(path)
 }
 
-// Readlink is a wrapper around unpriv.Readlink.
+// Readlink is equivalent to unpriv.Readlink.
 func (fs unprivFsEval) Readlink(path string) (string, error) {
 	return unpriv.Readlink(path)
 }
 
-// Symlink is a wrapper around unpriv.Symlink.
+// Symlink is equivalent to unpriv.Symlink.
 func (fs unprivFsEval) Symlink(linkname, path string) error {
 	return unpriv.Symlink(linkname, path)
 }
 
-// Link is a wrapper around unpriv.Link.
+// Link is equivalent to unpriv.Link.
 func (fs unprivFsEval) Link(linkname, path string) error {
 	return unpriv.Link(linkname, path)
 }
 
-// Chmod is a wrapper around unpriv.Chmod.
+// Chmod is equivalent to unpriv.Chmod.
 func (fs unprivFsEval) Chmod(path string, mode os.FileMode) error {
 	return unpriv.Chmod(path, mode)
 }
 
-// Lutimes is a wrapper around unpriv.Lutimes.
+// Lutimes is equivalent to unpriv.Lutimes.
 func (fs unprivFsEval) Lutimes(path string, atime, mtime time.Time) error {
 	return unpriv.Lutimes(path, atime, mtime)
 }
 
-// Remove is a wrapper around unpriv.Remove.
+// Remove is equivalent to unpriv.Remove.
 func (fs unprivFsEval) Remove(path string) error {
 	return unpriv.Remove(path)
 }
 
-// RemoveAll is a wrapper around unpriv.RemoveAll.
+// RemoveAll is equivalent to unpriv.RemoveAll.
 func (fs unprivFsEval) RemoveAll(path string) error {
 	return unpriv.RemoveAll(path)
 }
 
-// Mkdir is a wrapper around unpriv.Mkdir.
+// Mkdir is equivalent to unpriv.Mkdir.
 func (fs unprivFsEval) Mkdir(path string, perm os.FileMode) error {
 	return unpriv.Mkdir(path, perm)
 }
@@ -102,9 +102,34 @@ func (fs unprivFsEval) Mknod(path string, mode os.FileMode, dev system.Dev_t) er
 	return unpriv.Mknod(path, mode, dev)
 }
 
-// MkdirAll is a wrapper around unpriv.MkdirAll.
+// MkdirAll is equivalent to unpriv.MkdirAll.
 func (fs unprivFsEval) MkdirAll(path string, perm os.FileMode) error {
 	return unpriv.MkdirAll(path, perm)
+}
+
+// Llistxattr is equivalent to unpriv.Llistxattr
+func (fs unprivFsEval) Llistxattr(path string) ([]string, error) {
+	return unpriv.Llistxattr(path)
+}
+
+// Lremovexattr is equivalent to unpriv.Lremovexattr
+func (fs unprivFsEval) Lremovexattr(path, name string) error {
+	return unpriv.Lremovexattr(path, name)
+}
+
+// Lsetxattr is equivalent to unpriv.Lsetxattr
+func (fs unprivFsEval) Lsetxattr(path, name string, value []byte, flags int) error {
+	return unpriv.Lsetxattr(path, name, value, flags)
+}
+
+// Lgetxattr is equivalent to unpriv.Lgetxattr
+func (fs unprivFsEval) Lgetxattr(path string, name string) ([]byte, error) {
+	return unpriv.Lgetxattr(path, name)
+}
+
+// Lclearxattrs is equivalent to unpriv.Lclearxattrs
+func (fs unprivFsEval) Lclearxattrs(path string) error {
+	return unpriv.Lclearxattrs(path)
 }
 
 // KeywordFunc returns a wrapper around the given mtree.KeywordFunc.

--- a/hack/gomtree-0001-compare-always-diff-xattr-keys.patch
+++ b/hack/gomtree-0001-compare-always-diff-xattr-keys.patch
@@ -1,0 +1,40 @@
+From ad35cae4829188740a10e5d6f3983867858ef6a6 Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <asarai@suse.de>
+Date: Sat, 17 Dec 2016 20:14:17 +1100
+Subject: [PATCH] compare: always diff "xattr" keys
+
+Because of how xattr works (it will not be set on all files, but it's
+possible for it to be added to a file without changing any other key)
+it's necessary that we _always_ compute a diff when we hit an inode that
+has xattr keys set.
+
+Signed-off-by: Aleksa Sarai <asarai@suse.de>
+---
+ compare.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/compare.go b/compare.go
+index b2340b3df7e9..57fb4444d01f 100644
+--- a/compare.go
++++ b/compare.go
+@@ -192,7 +192,7 @@ func compareEntry(oldEntry, newEntry Entry) ([]KeyDelta, error) {
+ 	for _, kv := range oldKeys {
+ 		key := kv.Keyword()
+ 		// only add this diff if the new keys has this keyword
+-		if key != "tar_time" && key != "time" && HasKeyword(newKeys, key) == emptyKV {
++		if key != "tar_time" && key != "time" && key != "xattr" && HasKeyword(newKeys, key) == emptyKV {
+ 			continue
+ 		}
+ 
+@@ -211,7 +211,7 @@ func compareEntry(oldEntry, newEntry Entry) ([]KeyDelta, error) {
+ 	for _, kv := range newKeys {
+ 		key := kv.Keyword()
+ 		// only add this diff if the old keys has this keyword
+-		if key != "tar_time" && key != "time" && HasKeyword(oldKeys, key) == emptyKV {
++		if key != "tar_time" && key != "time" && key != "xattr" && HasKeyword(oldKeys, key) == emptyKV {
+ 			continue
+ 		}
+ 
+-- 
+2.11.0
+

--- a/hack/gomtree-0001-keywords-encode-xattr.-keywords-with-Vis.patch
+++ b/hack/gomtree-0001-keywords-encode-xattr.-keywords-with-Vis.patch
@@ -1,0 +1,47 @@
+From 6bc5e6130c1ff4c1d9057c671e4cd1c46a5eef0c Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <asarai@suse.de>
+Date: Sun, 18 Dec 2016 02:57:45 +1100
+Subject: [PATCH] keywords: encode xattr.* keywords with Vis
+
+This allows for xattr keywords to include spaces and other such options
+(which is perfectly valid according to the definition of Lsetxattr --
+any character except '\x00' is fair game).
+
+Signed-off-by: Aleksa Sarai <asarai@suse.de>
+---
+ keywords_linux.go | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/keywords_linux.go b/keywords_linux.go
+index 79cf46e8d7c1..a14108eae836 100644
+--- a/keywords_linux.go
++++ b/keywords_linux.go
+@@ -62,7 +62,11 @@ var (
+ 			}
+ 			klist := []KeyVal{}
+ 			for k, v := range hdr.Xattrs {
+-				klist = append(klist, KeyVal(fmt.Sprintf("xattr.%s=%s", k, base64.StdEncoding.EncodeToString([]byte(v)))))
++				encKey, err := Vis(k, DefaultVisFlags)
++				if err != nil {
++					return emptyKV, err
++				}
++				klist = append(klist, KeyVal(fmt.Sprintf("xattr.%s=%s", encKey, base64.StdEncoding.EncodeToString([]byte(v)))))
+ 			}
+ 			return KeyVal(strings.Join(KeyValToString(klist), " ")), nil
+ 		}
+@@ -80,7 +84,11 @@ var (
+ 			if err != nil {
+ 				return emptyKV, err
+ 			}
+-			klist[i] = KeyVal(fmt.Sprintf("xattr.%s=%s", xlist[i], base64.StdEncoding.EncodeToString(data)))
++			encKey, err := Vis(xlist[i], DefaultVisFlags)
++			if err != nil {
++				return emptyKV, err
++			}
++			klist[i] = KeyVal(fmt.Sprintf("xattr.%s=%s", encKey, base64.StdEncoding.EncodeToString(data)))
+ 		}
+ 		return KeyVal(strings.Join(KeyValToString(klist), " ")), nil
+ 	}
+-- 
+2.11.0
+

--- a/hack/patch.sh
+++ b/hack/patch.sh
@@ -36,3 +36,7 @@ patch github.com/opencontainers/image-spec imagespec-0001-specs-go-add-labels-to
 # project is, so I'm just going to backport it here until I see that there's
 # upstream activity.
 patch github.com/pkg/errors errors-0001-errors-add-Debug-function.patch
+
+# Inclusion of vbatts/go-mtree#108. This fixes issues with xattrs not being
+# correctly detected when new xattrs have been added.
+patch github.com/vbatts/go-mtree gomtree-0001-compare-always-diff-xattr-keys.patch

--- a/hack/patch.sh
+++ b/hack/patch.sh
@@ -40,3 +40,7 @@ patch github.com/pkg/errors errors-0001-errors-add-Debug-function.patch
 # Inclusion of vbatts/go-mtree#108. This fixes issues with xattrs not being
 # correctly detected when new xattrs have been added.
 patch github.com/vbatts/go-mtree gomtree-0001-compare-always-diff-xattr-keys.patch
+
+# Inclusion of vbatts/go-mtree#110. This fixes issues with spaces inside xattrs
+# (which is somethig that we have an integration test on).
+patch github.com/vbatts/go-mtree gomtree-0001-keywords-encode-xattr.-keywords-with-Vis.patch

--- a/vendor/github.com/vbatts/go-mtree/compare.go
+++ b/vendor/github.com/vbatts/go-mtree/compare.go
@@ -192,7 +192,7 @@ func compareEntry(oldEntry, newEntry Entry) ([]KeyDelta, error) {
 	for _, kv := range oldKeys {
 		key := kv.Keyword()
 		// only add this diff if the new keys has this keyword
-		if key != "tar_time" && key != "time" && HasKeyword(newKeys, key) == emptyKV {
+		if key != "tar_time" && key != "time" && key != "xattr" && HasKeyword(newKeys, key) == emptyKV {
 			continue
 		}
 
@@ -211,7 +211,7 @@ func compareEntry(oldEntry, newEntry Entry) ([]KeyDelta, error) {
 	for _, kv := range newKeys {
 		key := kv.Keyword()
 		// only add this diff if the old keys has this keyword
-		if key != "tar_time" && key != "time" && HasKeyword(oldKeys, key) == emptyKV {
+		if key != "tar_time" && key != "time" && key != "xattr" && HasKeyword(oldKeys, key) == emptyKV {
 			continue
 		}
 

--- a/vendor/github.com/vbatts/go-mtree/keywords_linux.go
+++ b/vendor/github.com/vbatts/go-mtree/keywords_linux.go
@@ -62,7 +62,11 @@ var (
 			}
 			klist := []KeyVal{}
 			for k, v := range hdr.Xattrs {
-				klist = append(klist, KeyVal(fmt.Sprintf("xattr.%s=%s", k, base64.StdEncoding.EncodeToString([]byte(v)))))
+				encKey, err := Vis(k, DefaultVisFlags)
+				if err != nil {
+					return emptyKV, err
+				}
+				klist = append(klist, KeyVal(fmt.Sprintf("xattr.%s=%s", encKey, base64.StdEncoding.EncodeToString([]byte(v)))))
 			}
 			return KeyVal(strings.Join(KeyValToString(klist), " ")), nil
 		}
@@ -80,7 +84,11 @@ var (
 			if err != nil {
 				return emptyKV, err
 			}
-			klist[i] = KeyVal(fmt.Sprintf("xattr.%s=%s", xlist[i], base64.StdEncoding.EncodeToString(data)))
+			encKey, err := Vis(xlist[i], DefaultVisFlags)
+			if err != nil {
+				return emptyKV, err
+			}
+			klist[i] = KeyVal(fmt.Sprintf("xattr.%s=%s", encKey, base64.StdEncoding.EncodeToString(data)))
 		}
 		return KeyVal(strings.Join(KeyValToString(klist), " ")), nil
 	}


### PR DESCRIPTION
This implements xattr handling in tar_generate, as well as some other
cleanups.

By necessity we have to ignore some xattrs (such as security.selinux),
but hopefully this is a rare case of things we need to ignore -- I don't
really want to have to maintain a set of xattrs that are and are not
safe to handle.

Fixes: cyphar/umoci#52
Signed-off-by: Aleksa Sarai <asarai@suse.com>