### PR TITLE
lgtm: add lgtm approval

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,0 +1,2 @@
+approval = 1
+pattern = "^LGTM"


### PR DESCRIPTION
This uses [lgtmco/lgtm][1] which is a free software LGTM approval service,
which is currently discontinued but I will spin up a service for my own
repos.

Since I'm currently the only maintainer, I have to allow self-approvals
and also only require one LGTM.

[1]: https://github.com/lgtmco/lgtm

Signed-off-by: Aleksa Sarai <asarai@suse.com>