### PR TITLE
fseval: add Mknod

### DIFF
--- a/fseval.go
+++ b/fseval.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cyphar/umoci/pkg/system"
 	"github.com/vbatts/go-mtree"
 )
 
@@ -70,6 +71,9 @@ type FsEval interface {
 
 	// MkdirAll is a wrapper around unpriv.MkdirAll.
 	MkdirAll(path string, perm os.FileMode) error
+
+	// Mknod is equivalent to system.Mknod.
+	Mknod(path string, mode os.FileMode, dev system.Dev_t) error
 
 	// KeywordFunc returns a wrapper around the given mtree.KeywordFunc.
 	KeywordFunc(fn mtree.KeywordFunc) mtree.KeywordFunc

--- a/fseval_default.go
+++ b/fseval_default.go
@@ -99,6 +99,11 @@ func (fs osFsEval) Mkdir(path string, perm os.FileMode) error {
 	return os.Mkdir(path, perm)
 }
 
+// Mknod is equivalent to system.Mknod.
+func (fs osFsEval) Mknod(path string, mode os.FileMode, dev system.Dev_t) error {
+	return system.Mknod(path, mode, dev)
+}
+
 // MkdirAll is a wrapper around unpriv.MkdirAll.
 func (fs osFsEval) MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)

--- a/fseval_rootless.go
+++ b/fseval_rootless.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cyphar/umoci/pkg/system"
 	"github.com/cyphar/umoci/pkg/unpriv"
 	"github.com/vbatts/go-mtree"
 )
@@ -94,6 +95,11 @@ func (fs unprivFsEval) RemoveAll(path string) error {
 // Mkdir is a wrapper around unpriv.Mkdir.
 func (fs unprivFsEval) Mkdir(path string, perm os.FileMode) error {
 	return unpriv.Mkdir(path, perm)
+}
+
+// Mknod is equivalent to unpriv.Mknod.
+func (fs unprivFsEval) Mknod(path string, mode os.FileMode, dev system.Dev_t) error {
+	return unpriv.Mknod(path, mode, dev)
 }
 
 // MkdirAll is a wrapper around unpriv.MkdirAll.

--- a/pkg/unpriv/unpriv.go
+++ b/pkg/unpriv/unpriv.go
@@ -428,3 +428,12 @@ func MkdirAll(path string, perm os.FileMode) error {
 		return nil
 	}), "unpriv.mkdirall")
 }
+
+// Mknod is a wrapper around os.Mknod which has been wrapped with unpriv.Wrap
+// to make it possible to remove a path even if you do not currently have the
+// required access bits to modify or resolve the path.
+func Mknod(path string, mode os.FileMode, dev system.Dev_t) error {
+	return errors.Wrap(Wrap(path, func(path string) error {
+		return system.Mknod(path, mode, dev)
+	}), "unpriv.mknod")
+}


### PR DESCRIPTION
This also includes the change to unpriv, so that we can do unprivileged
Mknod creation. Currently I haven't put the hacks done for devices
because that code is quite frankly pretty dark.

Signed-off-by: Aleksa Sarai <asarai@suse.com>