### PR TITLE
cmd: give 'helpful' hint about --rootless

### DIFF
--- a/cmd/umoci/main.go
+++ b/cmd/umoci/main.go
@@ -131,6 +131,12 @@ func main() {
 
 	// Actually run umoci.
 	if err := app.Run(os.Args); err != nil {
+		// If an error is a permission based error, give a hint to the user
+		// that --rootless might help. We probably should only be doing this if
+		// we're an unprivileged user.
+		if os.IsPermission(errors.Cause(err)) {
+			logrus.Infof("umoci encountered a permission error -- maybe --rootless will help?")
+		}
 		logrus.Fatalf("%v", err)
 	}
 }


### PR DESCRIPTION
We still need to massively reduce the amount of dumb output we are
spewing out. Logrus is both a blessing and a curse.

Reported-by: Antonio Murdaca <runcom@redhat.com>
Signed-off-by: Aleksa Sarai <asarai@suse.com>