### PR TITLE
gc: clean internal directories

### DIFF
--- a/oci/cas/cas.go
+++ b/oci/cas/cas.go
@@ -105,6 +105,12 @@ type Engine interface {
 	// ListReferences returns the set of reference names stored in the image.
 	ListReferences(ctx context.Context) (names []string, err error)
 
+	// GC executes a garbage collection of any non-blob garbage in the store
+	// (this includes temporary files and directories not reachable from the
+	// CAS interface). This MUST NOT remove any blobs or references in the
+	// store.
+	GC(ctx context.Context) (err error)
+
 	// Close releases all references held by the engine. Subsequent operations
 	// may fail.
 	Close() (err error)

--- a/oci/cas/gc.go
+++ b/oci/cas/gc.go
@@ -232,6 +232,11 @@ func GC(ctx context.Context, engine Engine) error {
 		n++
 	}
 
+	// Finally, tell CAS to GC it.
+	if err := engine.GC(ctx); err != nil {
+		return errors.Wrapf(err, "GC engine")
+	}
+
 	logrus.Infof("GC: garbage collected %d blobs", n)
 	return nil
 }

--- a/pkg/system/lock_linux.go
+++ b/pkg/system/lock_linux.go
@@ -1,0 +1,34 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system
+
+import "syscall"
+
+// Flock is a wrapper around flock(2).
+func Flock(fd uintptr, exclusive bool) error {
+	how := syscall.LOCK_SH
+	if exclusive {
+		how = syscall.LOCK_EX
+	}
+	return syscall.Flock(int(fd), how|syscall.LOCK_NB)
+}
+
+// Unflock is a wrapper around flock(2).
+func Unflock(fd uintptr) error {
+	return syscall.Flock(int(fd), syscall.LOCK_UN)
+}

--- a/test/gc.bats
+++ b/test/gc.bats
@@ -155,3 +155,31 @@ function teardown() {
 
 	image-verify "${IMAGE}"
 }
+
+@test "umoci gc [internal]" {
+	image-verify "${IMAGE}"
+
+	# Initial gc.
+	umoci gc --layout "${IMAGE}"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+
+	# Create unused directories.
+	touch "${IMAGE}/.internal"
+	touch "${IMAGE}/  magical file   "
+	mkdir "${IMAGE}/  __ internal __ directory"
+	touch "${IMAGE}/  __ internal __ directory/.abc"
+
+	# Do a gc, which should remove the temporary files/directories.
+	umoci gc --layout "${IMAGE}"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+
+	# Make sure it's gone.
+	! [ -e "${IMAGE}/.internal" ]
+	! [ -e "${IMAGE}/  magical file   " ]
+	! [ -e "${IMAGE}/  __ internal __ directory" ]
+	! [ -e "${IMAGE}/  __ internal __ directory/.abc" ]
+
+	image-verify "${IMAGE}"
+}


### PR DESCRIPTION
This adds support for cleaning of dead temporary directories inside
an OCI layout directory. It's all implemented using locking.

Fixes #17 
Signed-off-by: Aleksa Sarai <asarai@suse.com>