### PR TITLE
*: make unit tests more %check-friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ umociimage:
 .PHONY: test-unit
 test-unit: umociimage
 	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) --cap-add=SYS_ADMIN $(UMOCI_IMAGE) make local-test-unit
-	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -u 1000:1000 --cap-drop=all $(UMOCI_IMAGE) go test -v $(PROJECT)/pkg/unpriv
+	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -u 1000:1000 --cap-drop=all $(UMOCI_IMAGE) make local-test-unit
 
 .PHONY: local-test-unit
 local-test-unit: umoci

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO
 
 GO_SRC =  $(shell find . -name \*.go)
 umoci: $(GO_SRC)
-	$(GO) build -ldflags "-X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/umoci
+	$(GO) build -ldflags "-s -w -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/umoci
 
 umoci.static: $(GO_SRC)
-	CGO_ENABLED=0 $(GO) build -ldflags "-extldflags '-static' -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/umoci
+	CGO_ENABLED=0 $(GO) build -ldflags "-s -w -extldflags '-static' -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/umoci
 
 .PHONY: update-deps
 update-deps:
@@ -86,7 +86,7 @@ test-unit: umociimage
 
 .PHONY: local-test-unit
 local-test-unit: umoci
-	go test -v $(PROJECT)/...
+	go test -cover -v $(PROJECT)/...
 
 .PHONY: test-integration
 test-integration: umociimage

--- a/oci/cas/dir_test.go
+++ b/oci/cas/dir_test.go
@@ -40,6 +40,11 @@ import (
 
 // readonly makes the given path read-only (by bind-mounting it as "ro").
 func readonly(t *testing.T, path string) {
+	if os.Geteuid() != 0 {
+		t.Log("readonly tests only work with root privileges")
+		t.Skip()
+	}
+
 	t.Logf("mounting %s as readonly", path)
 
 	if err := syscall.Mount(path, path, "", syscall.MS_BIND|syscall.MS_RDONLY, ""); err != nil {
@@ -52,6 +57,11 @@ func readonly(t *testing.T, path string) {
 
 // readwrite undoes the effect of readonly.
 func readwrite(t *testing.T, path string) {
+	if os.Geteuid() != 0 {
+		t.Log("readonly tests only work with root privileges")
+		t.Skip()
+	}
+
 	if err := syscall.Unmount(path, syscall.MNT_DETACH); err != nil {
 		t.Fatalf("unmount %s: %s", path, err)
 	}

--- a/oci/layer/tar_extract_test.go
+++ b/oci/layer/tar_extract_test.go
@@ -463,6 +463,11 @@ func TestUnpackHardlink(t *testing.T) {
 
 // TestUnpackEntryMap checks that the mapOptions handling works.
 func TestUnpackEntryMap(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Log("mapOptions tests only work with root privileges")
+		t.Skip()
+	}
+
 	// TODO: Modify this to use subtests once Go 1.7 is in enough places.
 	func(t *testing.T) {
 		for _, test := range []struct {


### PR DESCRIPTION
This is necessary for %check-style testing inside the openSUSE RPMs, so
that we can make sure that everything works (or appears to work) when
releasing packages. This is done by making local-unit-tests work as
non-root.

It also increases unit test coverage for the rootless case.

Signed-off-by: Aleksa Sarai <asarai@suse.com>