### PR TITLE
*: make coverage optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test-unit: umociimage
 
 .PHONY: local-test-unit
 local-test-unit:
-	GO=$(GO) PROJECT=$(PROJECT) hack/test-unit.sh
+	GO=$(GO) COVER=1 hack/test-unit.sh
 
 .PHONY: test-integration
 test-integration: umociimage
@@ -105,7 +105,7 @@ test-integration: umociimage
 
 .PHONY: local-test-integration
 local-test-integration: umoci.cover
-	hack/test-integration.sh
+	COVER=1 hack/test-integration.sh
 
 shell: umociimage
 	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) $(UMOCI_IMAGE) bash

--- a/cmd/umoci/main_test.go
+++ b/cmd/umoci/main_test.go
@@ -28,7 +28,7 @@ import (
 //            -cover -coverpkg=github.com/cyphar/umoci/... \
 //            github.com/cyphar/umoci/cmd/umoci
 // Run:
-//  $ ./umoci --i-heard-you-like-tests -test.coverprofile [file] [args]...
+//  $ ./umoci __DEVEL--i-heard-you-like-tests -test.coverprofile [file] [args]...
 
 // TestUmoci is a hack that allows us to figure out what the coverage is during
 // integration tests. I would not recommend that you use a binary built using
@@ -41,9 +41,10 @@ func TestUmoci(t *testing.T) {
 
 	for _, arg := range os.Args {
 		switch {
-		case arg == "~~i-heard-you-like-tests":
+		case arg == "__DEVEL--i-heard-you-like-tests":
 			run = true
 		case strings.HasPrefix(arg, "-test"):
+		case strings.HasPrefix(arg, "__DEVEL"):
 		default:
 			args = append(args, arg)
 		}

--- a/hack/test-unit.sh
+++ b/hack/test-unit.sh
@@ -17,6 +17,7 @@
 set -ex
 
 GO="${GO:-go}"
+PROJECT="${PROJECT:-github.com/cyphar/umoci}"
 
 # Set up the root and coverage directories.
 export ROOT="$(readlink -f "$(dirname "$(readlink -f "$BASH_SOURCE")")/..")"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -68,8 +68,11 @@ function bundle-verify() {
 
 function umoci() {
 	local args=()
-	if [ "$COVERAGE_DIR" ]; then
-		args+=("-test.coverprofile=$(mktemp -p "$COVERAGE_DIR" umoci.cov.XXXXXX)" "~~i-heard-you-like-tests")
+	if [ "$COVER" -eq 1 ]; then
+		if [ "$COVERAGE_DIR" ]; then
+			args+=("-test.coverprofile=$(mktemp -p "$COVERAGE_DIR" umoci.cov.XXXXXX)")
+		fi
+		args+=("__DEVEL--i-heard-you-like-tests")
 	fi
 
 	# Set the first argument (the subcommand).
@@ -84,7 +87,7 @@ function umoci() {
 	args+=("$@")
 	sane_run "$UMOCI" "${args[@]}"
 
-	if [ "$COVERAGE_DIR" ]; then
+	if [ "$COVER" -eq 1 ]; then
 		# Because this is running as a -test.cover test, we need to remove the last
 		# two lines.
 		if [ "$status" -eq 0 ]; then


### PR DESCRIPTION
This makes the hack/test-* scripts work in a non-coverage mode that
allows users to run hack/test-integration with a regular umoci binary.

Signed-off-by: Aleksa Sarai <asarai@suse.com>