### PR TITLE
third_party: user: fix 32-bit build

### DIFF
--- a/hack/test-unit.sh
+++ b/hack/test-unit.sh
@@ -25,7 +25,7 @@ export COVERAGE_DIR=$(mktemp --tmpdir -d umoci-coverage.XXXXXX)
 
 # Run the tests and collate the results.
 for pkg in $(go list $PROJECT/...); do
-	$GO test -v -cover -covermode=count -coverprofile="$(mktemp --tmpdir=$COVERAGE_DIR cov.XXXXX)" -coverpkg=$PROJECT/... $pkg
+	$GO test -v -cover -covermode=count -coverprofile="$(mktemp --tmpdir=$COVERAGE_DIR cov.XXXXX)" -coverpkg=$PROJECT/... $pkg 2>/dev/null
 done
 [ "$COVERAGE" ] && $ROOT/hack/collate.awk $COVERAGE_DIR/* $COVERAGE | sponge $COVERAGE
 

--- a/third_party/user/user_test.go
+++ b/third_party/user/user_test.go
@@ -1,10 +1,10 @@
 package user
 
 import (
+	"fmt"
 	"io"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 	"unsafe"
@@ -444,7 +444,7 @@ this is just some garbage data
 	if int(unsafe.Sizeof(1)) > 4 {
 		tests = append(tests, foo{
 			// groups with too large id
-			groups:   []string{strconv.Itoa(1 << 31)},
+			groups:   []string{fmt.Sprintf("%d", 1<<31)},
 			expected: nil,
 			hasError: true,
 		})


### PR DESCRIPTION
The test code apparently breaks on i596, fix it by not using strconv
anymore.

Signed-off-by: Aleksa Sarai <asarai@suse.com>